### PR TITLE
Update dependencies to Symfony 2.2

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 #homepage:
-#    pattern:  /
+#    path:  /
 #    defaults: { _controller: TedivmStashBundle:Default:index }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   "require": {
     "php": ">=5.3.0",
     "tedivm/stash": "0.10.*",
-    "symfony/framework-bundle": "2.1.*",
-    "symfony/yaml": "2.1.*"
+    "symfony/framework-bundle": ">=2.2,<3.0",
+    "symfony/yaml": ">=2.2,<3.0"
   },
   "autoload": {
     "psr-0": {"Tedivm\\StashBundle": ""}


### PR DESCRIPTION
This change also makes sure future stable versions in 2.x series are accepted as dependencies.
