### PR TITLE
Update composer.json for 2.1.x dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   "require": {
     "php": ">=5.3.0",
     "tedivm/stash": "0.10.*",
-    "symfony/framework-bundle": ">=2.2,<3.0",
-    "symfony/yaml": ">=2.2,<3.0"
+    "symfony/framework-bundle": ">=2.1,<3.0",
+    "symfony/yaml": ">=2.1,<3.0"
   },
   "autoload": {
     "psr-0": {"Tedivm\\StashBundle": ""}


### PR DESCRIPTION
Stash Bundle does not innately require Symfony at or above 2.2 in order to function, but the composer.json file currently requires both the FrameworkBundle and YAML components to match that version number. This should be reverted to 2.1 until such a time as a commitment to a 2.2+ only release is made.
