### PR TITLE
Fixed contains in Doctrine Adapter

### DIFF
--- a/Adapters/DoctrineAdapter.php
+++ b/Adapters/DoctrineAdapter.php
@@ -84,7 +84,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
 
         $this->caches[$id] = $this->cacheService->getItem($id);
 
-        return $this->caches[$id]->isMiss();
+        return !$this->caches[$id]->isMiss(); 
     }
 
     /**


### PR DESCRIPTION
I had quite some erradic behaviour from our app after I changed the cache service to be based on stash instead of Doctrine Cache. I guess not a lot of people have used the adapter. It returned the opposite when asked if it contained an item :)
