### PR TITLE
Simplified dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,35 @@
 {
-  "name": "tedivm/stash-bundle",
-  "type": "symfony-bundle",
-  "description": "Incorporates the Stash caching library into Symfony.",
-  "keywords": ["caching","symfony","sessions"],
-  "homepage": "http://github.com/tedivm/TedivmStashBundle",
-  "license": "BSD-3-Clause",
-  "authors": [
-    {
-      "name": "Josh Hall-Bachner",
-      "email": "jhallbachner@gmail.com"
+    "name": "tedivm/stash-bundle",
+    "type": "symfony-bundle",
+    "description": "Incorporates the Stash caching library into Symfony.",
+    "keywords": ["caching","symfony","sessions"],
+    "homepage": "http://github.com/tedivm/TedivmStashBundle",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Josh Hall-Bachner",
+            "email": "jhallbachner@gmail.com"
+        },
+        {
+            "name": "Robert Hafner",
+            "email": "tedivm@tedivm.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "tedivm/stash": "dev-master",
+        "symfony/config": ">=2.1,<3.0",
+        "symfony/http-kernel": ">=2.1,<3.0",
+        "symfony/dependency-injection": ">=2.1,<3.0"
     },
-    {
-      "name": "Robert Hafner",
-      "email": "tedivm@tedivm.com"
-    }
-  ],
-  "require": {
-    "php": ">=5.3.0",
-    "tedivm/stash": "dev-master",
-    "symfony/framework-bundle": ">=2.1,<3.0",
-    "symfony/yaml": ">=2.1,<3.0"
-  },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",
         "fabpot/php-cs-fixer": "0.4.0",
         "satooshi/php-coveralls": "dev-master",
         "doctrine/cache": "~1.0"
     },
-  "autoload": {
-    "psr-0": {"Tedivm\\StashBundle": ""}
-  },
-  "target-dir": "Tedivm/StashBundle"
+    "autoload": {
+        "psr-0": {"Tedivm\\StashBundle": ""}
+    },
+    "target-dir": "Tedivm/StashBundle"
 }


### PR DESCRIPTION
Removed blanket “symfony/framework-bundle” and replaced it with the actual needed dependancies. 

The potential downside to this is that projects which do not properly define their own dependancies, and instead were relying on this bundle to define them instead, may have issues. This should be an easily resolvable issue though.

The upshot is that there are significantly less packages that composer will pull in, which should speed up CI systems and make packaged applications smaller.
