### PR TITLE
Stopped using deprecated Drivers::getDrivers method

### DIFF
--- a/Collector/CacheDataCollector.php
+++ b/Collector/CacheDataCollector.php
@@ -93,7 +93,7 @@ class CacheDataCollector extends DataCollector
             $info['caches'][$name]['hits'] = $hits;
         }
 
-        $drivers = Drivers::getDrivers();
+        $drivers = Drivers::getAvailableDrivers();
         foreach ($drivers as $name => $class) {
             if (!in_array($name, array('Ephemeral', 'Composite'))) {
                 $info['availableDrivers'][] = $name;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getCachesNode()
     {
-        $drivers = array_keys(Drivers::getDrivers());
+        $drivers = array_keys(Drivers::getAvailableDrivers());
 
         $treeBuilder = new TreeBuilder();
         $node = $treeBuilder->root('caches');

--- a/Factory/DriverFactory.php
+++ b/Factory/DriverFactory.php
@@ -32,7 +32,7 @@ class DriverFactory
      */
     public static function createDriver($types, $options)
     {
-        $drivers = Drivers::getDrivers();
+        $drivers = Drivers::getAvailableDrivers();
 
         $h = array();
 

--- a/Service/CacheService.php
+++ b/Service/CacheService.php
@@ -96,7 +96,7 @@ class CacheService extends Pool
      */
     public function getDrivers()
     {
-        return Drivers::getDrivers();
+        return Drivers::getAvailableDrivers();
     }
 
     /**

--- a/Tests/Collector/CacheDataCollectorTest.php
+++ b/Tests/Collector/CacheDataCollectorTest.php
@@ -113,7 +113,7 @@ class CacheDataCollectorTest extends \PHPUnit_Framework_TestCase
         $drivers = $collector->getDrivers();
         $this->assertInternalType('array', $drivers, 'getDrivers returns an array');
 
-        $systemDrivers = array_keys(Drivers::getDrivers());
+        $systemDrivers = array_keys(Drivers::getAvailableDrivers());
 
         $this->assertFalse(in_array('Ephemeral', $drivers), 'getDrivers does not include Ephemeral driver');
         $this->assertFalse(in_array('Composite', $drivers), 'getDrivers does not include Composite driver');

--- a/Tests/Factory/DriverFactoryTest.php
+++ b/Tests/Factory/DriverFactoryTest.php
@@ -66,7 +66,7 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->drivers = Drivers::getDrivers();
+        $this->drivers = Drivers::getAvailableDrivers();
     }
 
     /**

--- a/Tests/Service/CacheServiceTest.php
+++ b/Tests/Service/CacheServiceTest.php
@@ -64,7 +64,7 @@ class CacheServiceTest extends \Stash\Test\AbstractPoolTest
     public function testGetDrivers()
     {
         $service = $this->getCacheService();
-        $this->assertEquals(Drivers::getDrivers(), $service->getDrivers(), 'Service available drivers');
+        $this->assertEquals(Drivers::getAvailableDrivers(), $service->getDrivers(), 'Service available drivers');
     }
 
     public function testCacheService()


### PR DESCRIPTION
Updated to use Drivers::getAvailableDrivers instead.
