### PR TITLE
Reflect change from loggin to tracking in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ When multiple caches are defined, you can manually define a default, which will 
 
 If you don't, the first service defined will be set as the default.
 
-### Logging ###
+### Tracking ###
 
-StashBundle includes a module which logs the keys of all cache queries made during a request for debugging purposes. By
-default this module is enabled in the `dev` and `test` environments but disabled elsewhere. However, if you want to
+StashBundle includes a module which tracks the keys of all cache queries made during a request for debugging purposes.
+By default this module is enabled in the `dev` and `test` environments but disabled elsewhere. However, if you want to 
 override the default behavior, you can enable or disable this behavior in the configuration:
 
     stash:
-        logging: true # enables query logging, false to disable
+        tracking: true # enables query logging, false to disable
 
 ## Stash Driver Configuration ##
 


### PR DESCRIPTION
Hi. This is my first pr here. I was looking to README file and i couldn't disable database logging until i realized that setting was changed to tracking as is stated [here](http://www.stashphp.com/Symfony.html).

Hope it helps.
