### PR TITLE
Fixing README for example usage of session handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Once it's enabled, enable it in the framework bundle and it will automatically b
 
     framework:
         session:
-            driver_id: stash.adapter.session.default_cache
+            handler_id: stash.adapter.session.default_cache
 
 ### Multiple Services ###
 


### PR DESCRIPTION
#45 introduced a documentation error. When configuring framework's session section to use stash driver, an invalid config key was referred.
