### PR TITLE
Configurable logger

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -126,7 +126,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('registerDoctrineAdapter')->defaultFalse()->end()
             ->booleanNode('registerSessionHandler')->defaultFalse()->end()
             ->booleanNode('inMemory')->defaultTrue()->end()
-            ->scalarNode('logger')->end()
+            ->scalarNode('logger')->defaultNull()->end()
         ;
 
         foreach ($drivers as $driver) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -126,6 +126,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('registerDoctrineAdapter')->defaultFalse()->end()
             ->booleanNode('registerSessionHandler')->defaultFalse()->end()
             ->booleanNode('inMemory')->defaultTrue()->end()
+            ->scalarNode('logger')->end()
         ;
 
         foreach ($drivers as $driver) {

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -101,8 +101,9 @@ class TedivmStashExtension extends Extension
             ->setAbstract(false)
         ;
 
+        $cacheDefinition = new DefinitionDecorator('stash.cache');
         $container
-            ->setDefinition(sprintf('stash.%s_cache', $name), new DefinitionDecorator('stash.cache'))
+            ->setDefinition(sprintf('stash.%s_cache', $name), $cacheDefinition)
             ->setArguments(array(
                 $name,
                 new Reference(sprintf('stash.driver.%s_cache', $name)),
@@ -110,6 +111,10 @@ class TedivmStashExtension extends Extension
             ))
             ->setAbstract(false)
         ;
+            
+        if (isset($cache['logger']) && $cache['logger']) {
+            $cacheDefinition->addMethodCall('setLogger', array(new Reference($cache['logger'])));
+        }
 
         if (interface_exists("\\Doctrine\\Common\\Cache\\Cache") && $doctrine) {
             $container

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -111,7 +111,7 @@ class TedivmStashExtension extends Extension
             ))
             ->setAbstract(false)
         ;
-            
+
         if (isset($cache['logger']) && $cache['logger']) {
             $cacheDefinition->addMethodCall('setLogger', array(new Reference($cache['logger'])));
         }

--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ Once it's enabled, enable it in the framework bundle and it will automatically b
     framework:
         session:
             handler_id: stash.adapter.session.default_cache
+            
+### Logger ###
+
+Stash supports PSR Compliant logging libraries, you can specify which library is used by passing the logger's
+service name as a parameter:
+
+	stash:
+		drivers: [ FileSystem ]
+		logger: logger
+		FileSystem: ~ 
 
 ### Multiple Services ###
 
@@ -164,7 +174,8 @@ You can also configure multiple services, each of which stores is entirely separ
             second:
                 drivers: [ Apc, FileSystem ]
                 inMemory: false
-                FileSystem ~
+                logger: logger
+                FileSystem: ~
 
 Each service is defined with keys inside a separate, distinct internal namespace, so you can use multiple services to
 avoid key collisions between distinct services even if you only have a single backend available.

--- a/Tests/DependencyInjection/TedivmStashExtensionTest.php
+++ b/Tests/DependencyInjection/TedivmStashExtensionTest.php
@@ -51,6 +51,11 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                 $value = isset($cache[$item]) ? $cache[$item] : false;
                 $this->assertEquals($cacheoptions[$item], $value);
             }
+			
+            foreach (array('logger') as $item) {
+                $value = isset($cache[$item]) ? $cache[$item] : null;
+                $this->assertEquals($cacheoptions[$item], $value);
+            }
 
             if (isset($cache['drivers'])) {
                 foreach ($cache['drivers'] as $driver) {
@@ -107,6 +112,7 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                             'drivers' => array('SQLite'),
                             'registerDoctrineAdapter' => true,
                             'registerSessionHandler' => false,
+                            'logger' => null,
                             'inMemory' => true,
                             'SQLite' => array(
                                 'filePermissions'   => 0550,
@@ -118,6 +124,7 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                             'drivers' => array('FileSystem', 'SQLite'),
                             'registerDoctrineAdapter' => true,
                             'registerSessionHandler' => true,
+                            'logger' => 'logger',
                             'inMemory' => true,
                             'FileSystem' => array(
                                 'filePermissions'   => 0770,

--- a/Tests/DependencyInjection/TedivmStashExtensionTest.php
+++ b/Tests/DependencyInjection/TedivmStashExtensionTest.php
@@ -51,7 +51,7 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                 $value = isset($cache[$item]) ? $cache[$item] : false;
                 $this->assertEquals($cacheoptions[$item], $value);
             }
-			
+
             foreach (array('logger') as $item) {
                 $value = isset($cache[$item]) ? $cache[$item] : null;
                 $this->assertEquals($cacheoptions[$item], $value);


### PR DESCRIPTION
As initially discussed in issue https://github.com/tedious/TedivmStashBundle/issues/60, this pull request adds a 'logger' config parameter to caches so that they may be injected when each cache is created. 

An example config:

    stash:
        caches:
            first:
                drivers: [ FileSystem ]
                registerDoctrineAdapter: true
                FileSystem: ~
                logger: logger
            second:
                drivers: [ Apc, FileSystem ]
                inMemory: false
                FileSystem ~
                logger: another_logger_service_name