### PR TITLE
Made correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ stash: ~
 Just fetch the default cache pool service:
 
 ```php
-$pool = $this->container->get('cache');
+$pool = $this->container->get('stash');
 ```
 
 Or a custom-defined cache pool:


### PR DESCRIPTION
When making services dependent on "@cache" I was getting this error:

The service "xxx.xxx" has a dependency on a non-existent service "cache".

Switching to "@stash" fixed the issue - I also executed the "container:debug" command and it showed that "stash" was set up as an alias but had no entry for "cache".