### PR TITLE
symfony/symfony 2.7.0 compatibility fix

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,10 +19,9 @@
         <service id="stash.driver"
             class="%stash.driver.class%"
             abstract="true"
-            synthetic="true"
-            factory-method="createDriver"
-            factory-class="%stash.factory.class%"
-        />
+            synthetic="true">
+            <factory class="%stash.factory.class%" method="createDriver" />
+        </service>
         <service id="stash.adapter.doctrine" class="%stash.adapter.doctrine.class%" abstract="true"/>
         <service id="stash.adapter.session" class="%stash.adapter.session.class%" abstract="true"/>
         <service id="data_collector.stash" class="%stash.data_collector.class%">


### PR DESCRIPTION
In 2.7.0 those DIC methods were removed (BC break) thus container building crashes.

This is NOT compatible with versions older than 2.6.0.

DOC: http://symfony.com/doc/2.7/components/dependency_injection/factories.html