### PR TITLE
Add tracking_values to control tracking of cache values

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -80,6 +80,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('default_cache')->end()
                 ->booleanNode('tracking')->end()
+                ->booleanNode('tracking_values')->defaultTrue()->end()
             ->end()
             ->fixXmlConfig('cache')
             ->append($this->getCachesNode())
@@ -251,7 +252,7 @@ class Configuration implements ConfigurationInterface
     {
         $cache = array();
         foreach ($v as $key => $value) {
-            if (in_array($key, array('default_cache', 'tracking'))) {
+            if (in_array($key, array('default_cache', 'tracking', 'tracking_values'))) {
                 continue;
             }
             $cache[$key] = $v[$key];

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -52,6 +52,9 @@ class TedivmStashExtension extends Extension
             : (in_array($container->getParameter('kernel.environment'), array('dev', 'test')));
         $container->setParameter('stash.tracker', $lq);
 
+        $lqv = isset($config['tracking_values']) ? $config['tracking_values'] : true;
+        $container->setParameter('stash.tracking_values', $lqv);
+
         $caches = array();
         $options = array();
         foreach ($config['caches'] as $name => $cache) {
@@ -68,6 +71,7 @@ class TedivmStashExtension extends Extension
     protected function addCacheService($name, $cache, $container)
     {
         $logqueries = $container->getParameter('stash.tracker');
+        $logQueryValues = $container->getParameter('stash.tracking_values');
         $drivers = isset($cache['drivers']) ? $cache['drivers'] : array();
 
         unset($cache['drivers']);
@@ -98,6 +102,7 @@ class TedivmStashExtension extends Extension
                 $name
             ))
             ->addMethodCall('enableQueryLogging', array($logqueries))
+            ->addMethodCall('enableQueryValueLogging', array($logQueryValues))
             ->setAbstract(false)
         ;
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ override the default behavior, you can enable or disable this behavior in the co
 ```yaml
 stash:
     tracking: true # enables query logging, false to disable
+    tracking_values: true # enables query logging of full cache values, false to disable
 ```
 
 ## Stash Driver Configuration ##

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -247,6 +247,7 @@ disable this behavior in the configuration:
 
     stash:
         tracking: true # enables query logging, false to disable
+        tracking_values: true # enables query logging of full cache values, false to disable
 
 Stash Driver Configuration
 --------------------------

--- a/Service/CacheTracker.php
+++ b/Service/CacheTracker.php
@@ -55,6 +55,13 @@ class CacheTracker
      */
     protected $logQueries = true;
 
+    /**
+     *  Whether to log cache values of the individual queries when $logQueries is enabled.
+     *
+     * @var bool
+     */
+    protected $logQueryValues = true;
+
     public function __construct($name)
     {
         $this->name = $name;
@@ -68,6 +75,18 @@ class CacheTracker
     public function enableQueryLogging($lq = true)
     {
         $this->logQueries = $lq;
+    }
+
+    /**
+     * Enables or disables query value logging.
+     *
+     * @see $logQueryValues
+     *
+     * @param boolean $logQueryValues
+     */
+    public function enableQueryValueLogging($logQueryValues = true)
+    {
+        $this->logQueryValues = $logQueryValues;
     }
 
     /**
@@ -89,7 +108,12 @@ class CacheTracker
         }
 
         $hit = $hit ? 'true' : 'false';
-        $value = sprintf('(%s) %s', gettype($value), print_r($value, true));
+
+        if ($this->logQueryValues) {
+            $value = sprintf('(%s) %s', gettype($value), print_r($value, true));
+        } else {
+            $value = sprintf('(%s)', gettype($value));
+        }
 
         $this->queries[] = array(
             'key'   => $key,

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -55,14 +55,15 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizeCacheConfig()
     {
-        $testData = array('default_cache' => 'test', 'tracking' => 'test');
+        $testData = array('default_cache' => 'test', 'tracking' => 'test', 'tracking_values' => 'test2');
         $returnedData = Configuration::normalizeCacheConfig($testData);
 
         $this->assertInternalType('array', $returnedData, 'Returns array.');
         $this->assertArrayHasKey('default_cache', $returnedData, 'Normalization skips default_cache');
         $this->assertArrayHasKey('tracking', $returnedData, 'Normalization skips tracking');
+        $this->assertArrayHasKey('tracking_values', $returnedData, 'Normalization skips tracking_values');
 
-        $testData = array('tracking' => 'test');
+        $testData = array('tracking' => 'test', 'tracking_values' => 'test2');
         $returnedData = Configuration::normalizeCacheConfig($testData);
         $this->assertArrayHasKey('default_cache', $returnedData, 'Normalization adds default_cache when missing');
 

--- a/Tests/Service/CacheTrackerTest.php
+++ b/Tests/Service/CacheTrackerTest.php
@@ -106,6 +106,31 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $tracker->getQueries(), 'Tracker does not track queries when tracking is disabled');
     }
 
+    public function testGetQueriesNoValues()
+    {
+        $tracker = $this->testConstruct('unpopulated');
+        $tracker->enableQueryValueLogging(false);
+        $tracker = $this->getPopulatedTracker($tracker);
+
+        $queries = $tracker->getQueries();
+        $this->assertCount(6, $queries, 'Tracker returns queries passed to it.');
+
+        $tracker->trackRequest('Key6', false, 'Value6');
+        $queries = $tracker->getQueries();
+        $this->assertCount(7, $queries, 'Tracker returns queries with duplicate keys.');
+
+        $data = $this->getData();
+
+        foreach ($data as $index => $datum) {
+            $query = $queries[$index];
+            $expectedTruth = $datum[1] ? 'true' : 'false';
+            $expectedValue = explode(" ", $datum[3], 2)[0];
+            $this->assertEquals($datum[0], $query['key'], 'getQueries returns key for data example ' . $index);
+            $this->assertEquals($expectedTruth, $query['hit'], 'getQueries returns hit status as string for data example ' . $index);
+            $this->assertEquals($expectedValue, $query['value'], 'getQueries returns value for data example ' . $index);
+        }
+    }
+
     protected function getPopulatedTracker($tracker = null)
     {
         if (is_null($tracker)) {


### PR DESCRIPTION
Cache values can on some systems be rather big, combined with
many cache calls it can lead to several gigabyte sized Symfony profile files.

This option allows you to still see track what cache lookups are done and what kind of data is returned, but skipping the value itself.

Closes #74

Open:
- [x] Doc
- [x] Tests