### PR TITLE
setOptions on drivers is called twice

### DIFF
--- a/Factory/DriverFactory.php
+++ b/Factory/DriverFactory.php
@@ -65,8 +65,7 @@ class DriverFactory
             }
 
             $opts = isset($options[$type]) ? $options[$type] : array();
-            $driver = new $class();
-            $driver->setOptions($opts);
+            $driver = new $class($opts);
             $h[] = $driver;
         }
 
@@ -75,8 +74,7 @@ class DriverFactory
         }
 
         $class = $drivers['Composite'];
-        $driver = new $class();
-        $driver->setOptions(array('drivers' => $h));
+        $driver = new $class(array('drivers' => $h));
 
         return $driver;
     }


### PR DESCRIPTION
We were having some trouble with the DriverFactory. In some drivers, specifically in our case, the FileSystem driver, the setOptions method has side-effects. The FileSystem driver creates the cache path, but even if it didn't we'd still have troubles, because it throws exceptions if there's something wrong with the cache path.

Because of this it's important that the cache path passed to the Filesystem driver is correct. If it isn't we're attempting to create directories, or possibly getting exceptions thrown.

Before this patch, setOptions were being called twice for all drivers. Once in the constructor of AbstractDriver, with the default (and in our case non-working) options, and once intentionally in the DriverFactory (with the correct options).

This patch removes the unnecessary and possibly erroneous call by passing the options to the constructor instead of with a dedicated setOptions call.