### PR TITLE
Fix for huge memory consumption when tracking big objects.

### DIFF
--- a/Service/CacheTracker.php
+++ b/Service/CacheTracker.php
@@ -110,9 +110,9 @@ class CacheTracker
         $hit = $hit ? 'true' : 'false';
 
         if ($this->logQueryValues) {
-            if(is_object($value)){
+            if (is_object($value)) {
                 $readyVal = serialize($value);
-            }else{
+            } else {
                 $readyVal = print_r($value, true);
             }
             $value = sprintf('(%s) %s', gettype($value), $readyVal);

--- a/Service/CacheTracker.php
+++ b/Service/CacheTracker.php
@@ -110,7 +110,12 @@ class CacheTracker
         $hit = $hit ? 'true' : 'false';
 
         if ($this->logQueryValues) {
-            $value = sprintf('(%s) %s', gettype($value), @print_r($value, true));
+            if(is_object($value)){
+                $readyVal = serialize($value);
+            }else{
+                $readyVal = print_r($value, true);
+            }
+            $value = sprintf('(%s) %s', gettype($value), $readyVal);
         } else {
             $value = sprintf('(%s)', gettype($value));
         }

--- a/Tests/Service/CacheTrackerTest.php
+++ b/Tests/Service/CacheTrackerTest.php
@@ -151,7 +151,7 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
             array('Key1', true, 'Value1', '(string) Value1'),
             array('Key2', false, 2, '(integer) 2'),
             array('Key3', true, array(), "(array) Array\n(\n)\n"),
-            array('Key4', false, new \stdClass(), "(object) stdClass Object\n(\n)\n"),
+            array('Key4', false, new \stdClass(), "(object) ".serialize(new \stdClass())),
             array('Key5', true, 'Value5', '(string) Value5'),
             array('Key6', false, 'Value6', '(string) Value6'),
         );


### PR DESCRIPTION
Fix for very huge objects (like documents from mongo) and removed STFU (@) operator, it hides all errors (like memory exceeded).