### PR TITLE
Allow Symfony 3.0.1 and following updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "require": {
         "php": ">=5.3.0",
         "tedivm/stash": "0.13.*",
-        "symfony/config": ">=2.1,<=3.0",
-        "symfony/http-kernel": ">=2.1,<=3.0",
-        "symfony/dependency-injection": ">=2.1,<=3.0"
+        "symfony/config": "~2.1|~3.0",
+        "symfony/http-kernel": "~2.1|~3.0",
+        "symfony/dependency-injection": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",


### PR DESCRIPTION
The current composer.json file does not allow to install any upcoming Symfony3 versions like the current latest version 3.0.1.