### PR TITLE
[Composer] Update dev dependencies

### DIFF
--- a/Adapters/DoctrineAdapter.php
+++ b/Adapters/DoctrineAdapter.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the StashBundle package.
  *
@@ -11,11 +10,12 @@
  */
 
 namespace Tedivm\StashBundle\Adapters;
+
 use Doctrine\Common\Cache\Cache as DoctrineCacheInterface;
 
 /**
- * Class DoctrineAdapter
- * @package Tedivm\StashBundle\Adapters
+ * Class DoctrineAdapter.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -43,7 +43,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
     protected $caches = array();
 
     /**
-     * Initializes
+     * Initializes.
      *
      * @param \Tedivm\StashBundle\Service\CacheService $cacheService
      */
@@ -73,7 +73,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fetch($id)
     {
@@ -85,7 +85,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function contains($id)
     {
@@ -96,7 +96,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function save($id, $data, $lifeTime = 0)
     {
@@ -109,11 +109,10 @@ class DoctrineAdapter implements DoctrineCacheInterface
         $item = $this->cacheService->getItem($id);
 
         return $item->set($data, $lifeTime);
-
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function delete($id)
     {
@@ -128,7 +127,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getStats()
     {
@@ -160,6 +159,7 @@ class DoctrineAdapter implements DoctrineCacheInterface
      * Standardizes the cache key id in order to separate cache items by namespace.
      *
      * @param $id
+     *
      * @return string
      */
     protected function normalizeId($id)

--- a/Adapters/SessionHandlerAdapter.php
+++ b/Adapters/SessionHandlerAdapter.php
@@ -15,8 +15,8 @@ namespace Tedivm\StashBundle\Adapters;
 use Stash\Session;
 
 /**
- * Class SessionHandlerAdapter
- * @package Tedivm\StashBundle\Adapters
+ * Class SessionHandlerAdapter.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -24,9 +24,9 @@ class SessionHandlerAdapter extends Session
 {
     protected function getCache($session_id)
     {
-        $path = 'ss_ss/' .
-            base64_encode($this->path) . '/' .
-            base64_encode($this->name) . '/' .
+        $path = 'ss_ss/'.
+            base64_encode($this->path).'/'.
+            base64_encode($this->name).'/'.
             base64_encode($session_id);
 
         return $this->pool->getItem($path);

--- a/Collector/CacheDataCollector.php
+++ b/Collector/CacheDataCollector.php
@@ -11,18 +11,18 @@
  */
 
 namespace Tedivm\StashBundle\Collector;
+
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Stash\DriverList;
 
 /**
- * Class CacheDataCollector
+ * Class CacheDataCollector.
  *
  * Collects data stored in the static variables of the Stash class for use in profiling/debugging. Currently
  * records total cache calls and returns, along with calls and returns on each individual cache node.
  *
- * @package Tedivm\StashBundle\Collector
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -74,7 +74,7 @@ class CacheDataCollector extends DataCollector
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,14 +18,13 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Stash\DriverList;
 
 /**
- * Class Configuration
- * @package Tedivm\StashBundle\DependencyInjection
+ * Class Configuration.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
 class Configuration implements ConfigurationInterface
 {
-
     /**
      *  Default settings for various drivers.
      *
@@ -33,31 +32,31 @@ class Configuration implements ConfigurationInterface
      */
     protected $driverSettings = array(
         'FileSystem' => array(
-            'dirSplit'          => 2,
-            'path'              => '%kernel.cache_dir%/stash',
-            'filePermissions'   => 0660,
-            'dirPermissions'    => 0770,
-            'memKeyLimit'       => 200,
-            'keyHashFunction'   => 'md5',
-            'encoder'           => 'Native'
+            'dirSplit' => 2,
+            'path' => '%kernel.cache_dir%/stash',
+            'filePermissions' => 0660,
+            'dirPermissions' => 0770,
+            'memKeyLimit' => 200,
+            'keyHashFunction' => 'md5',
+            'encoder' => 'Native',
         ),
         'SQLite' => array(
-            'filePermissions'   => 0660,
-            'dirPermissions'    => 0770,
-            'busyTimeout'       => 500,
-            'nesting'           => 0,
-            'subhandler'        => 'PDO',
-            'version'           => null,
-            'path'              => '%kernel.cache_dir%/stash',
+            'filePermissions' => 0660,
+            'dirPermissions' => 0770,
+            'busyTimeout' => 500,
+            'nesting' => 0,
+            'subhandler' => 'PDO',
+            'version' => null,
+            'path' => '%kernel.cache_dir%/stash',
         ),
         'Apc' => array(
-            'ttl'               => 300,
-            'namespace'         => null,
+            'ttl' => 300,
+            'namespace' => null,
         ),
     );
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
@@ -152,8 +151,8 @@ class Configuration implements ConfigurationInterface
             ->arrayNode($driver)
                 ->fixXmlConfig('server');
 
-            if ($driver == 'Memcache') {
-                $finalNode = $driverNode
+        if ($driver == 'Memcache') {
+            $finalNode = $driverNode
                     ->info('All options except "servers" are Memcached options. See http://www.php.net/manual/en/memcached.constants.php')
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -192,9 +191,9 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                ;
-            } elseif ($driver == 'Redis') {
-                $finalNode = $driverNode
-                    ->info("Accepts server info, password, and database.")
+        } elseif ($driver == 'Redis') {
+            $finalNode = $driverNode
+                    ->info('Accepts server info, password, and database.')
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('password')->end()
@@ -215,26 +214,26 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ;
-            } else {
-                $defaults = isset($this->driverSettings[$driver]) ? $this->driverSettings[$driver] : array();
+        } else {
+            $defaults = isset($this->driverSettings[$driver]) ? $this->driverSettings[$driver] : array();
 
-                $node = $driverNode
+            $node = $driverNode
                     ->addDefaultsIfNotSet()
                     ->children();
 
-                    foreach ($defaults as $setting => $default) {
-                        $node
+            foreach ($defaults as $setting => $default) {
+                $node
                             ->scalarNode($setting)
                             ->defaultValue($default)
                             ->end()
                         ;
-                    }
-
-                    $finalNode = $node->end()
-                ;
             }
 
-            $finalNode->end()
+            $finalNode = $node->end()
+                ;
+        }
+
+        $finalNode->end()
         ;
     }
 
@@ -245,7 +244,8 @@ class Configuration implements ConfigurationInterface
      * single cache being used. This makes for less nesting and a prettier config, especially since most cases will
      * only involve a single caching system anyways.
      *
-     * @param  array $v
+     * @param array $v
+     *
      * @return array
      */
     public static function normalizeCacheConfig($v)
@@ -269,7 +269,8 @@ class Configuration implements ConfigurationInterface
      *
      * Sets the first defined cache as the default when the user hasn't explicitly set one.
      *
-     * @param  array $v
+     * @param array $v
+     *
      * @return array
      */
     public static function normalizeDefaultCacheConfig($v)
@@ -285,7 +286,8 @@ class Configuration implements ConfigurationInterface
      *
      * This converts the old "handlers" field into the new "drivers" field.
      *
-     * @param  array $v
+     * @param array $v
+     *
      * @return array
      */
     public static function normalizeHandlerToDriverConfig($v)

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -21,19 +21,17 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
- * Class TedivmStashExtension
+ * Class TedivmStashExtension.
  *
  * Bundle extension to handle configuration of the Stash bundle. Based on the specification provided
  * in the configuration file, this extension instantiates and dynamically injects the selected caching provider into
  * the Stash service, passing it any driver-specific settings from the configuration.
  *
- * @package Tedivm\StashBundle\DependencyInjection
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
 class TedivmStashExtension extends Extension
 {
-
     /**
      * {@inheritdoc}
      */
@@ -91,7 +89,7 @@ class TedivmStashExtension extends Extension
             ->setDefinition(sprintf('stash.driver.%s_cache', $name), new DefinitionDecorator('stash.driver'))
             ->setArguments(array(
                 $drivers,
-                $cache
+                $cache,
             ))
             ->setAbstract(false)
         ;
@@ -99,7 +97,7 @@ class TedivmStashExtension extends Extension
         $container
             ->setDefinition(sprintf('stash.tracker.%s_cache', $name), new DefinitionDecorator('stash.tracker'))
             ->setArguments(array(
-                $name
+                $name,
             ))
             ->addMethodCall('enableQueryLogging', array($logqueries))
             ->addMethodCall('enableQueryValueLogging', array($logQueryValues))
@@ -112,7 +110,7 @@ class TedivmStashExtension extends Extension
             ->setArguments(array(
                 $name,
                 new Reference(sprintf('stash.driver.%s_cache', $name)),
-                new Reference(sprintf('stash.tracker.%s_cache', $name))
+                new Reference(sprintf('stash.tracker.%s_cache', $name)),
             ))
             ->setAbstract(false)
         ;
@@ -121,11 +119,11 @@ class TedivmStashExtension extends Extension
             $cacheDefinition->addMethodCall('setLogger', array(new Reference($cache['logger'])));
         }
 
-        if (interface_exists("\\Doctrine\\Common\\Cache\\Cache") && $doctrine) {
+        if (interface_exists('\\Doctrine\\Common\\Cache\\Cache') && $doctrine) {
             $container
                 ->setDefinition(sprintf('stash.adapter.doctrine.%s_cache', $name), new DefinitionDecorator('stash.adapter.doctrine'))
                 ->setArguments(array(
-                    new Reference(sprintf('stash.%s_cache', $name))
+                    new Reference(sprintf('stash.%s_cache', $name)),
                 ))
                 ->setAbstract(false)
             ;
@@ -135,7 +133,7 @@ class TedivmStashExtension extends Extension
             $container
                 ->setDefinition(sprintf('stash.adapter.session.%s_cache', $name), new DefinitionDecorator('stash.adapter.session'))
                 ->setArguments(array(
-                    new Reference(sprintf('stash.%s_cache', $name))
+                    new Reference(sprintf('stash.%s_cache', $name)),
                 ))
                 ->setAbstract(false)
             ;
@@ -144,10 +142,9 @@ class TedivmStashExtension extends Extension
         $container
             ->getDefinition('data_collector.stash')
                 ->addMethodCall('addTracker', array(
-                    new Reference(sprintf('stash.tracker.%s_cache', $name))
+                    new Reference(sprintf('stash.tracker.%s_cache', $name)),
                 ))
         ;
-
     }
 
     /**

--- a/Factory/DriverFactory.php
+++ b/Factory/DriverFactory.php
@@ -11,12 +11,13 @@
  */
 
 namespace Tedivm\StashBundle\Factory;
+
 use Stash\DriverList;
 use Stash\Interfaces\DriverInterface;
 
 /**
- * Class DriverFactory
- * @package Tedivm\StashBundle\Factory
+ * Class DriverFactory.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -27,7 +28,9 @@ class DriverFactory
      *
      * @param $types
      * @param $options
+     *
      * @throws \RuntimeException
+     *
      * @return DriverInterface
      */
     public static function createDriver($types, $options)
@@ -37,7 +40,6 @@ class DriverFactory
         $h = array();
 
         foreach ($types as $type) {
-
             if (!isset($drivers[$type])) {
                 $allDrivers = DriverList::getAllDrivers();
 
@@ -57,7 +59,7 @@ class DriverFactory
                     $servers[] = array(
                         $serverSpec['server'],
                         $serverSpec['port'],
-                        isset($serverSpec['weight']) ? $serverSpec['weight'] : null
+                        isset($serverSpec['weight']) ? $serverSpec['weight'] : null,
                     );
                 }
 

--- a/Service/CacheItem.php
+++ b/Service/CacheItem.php
@@ -11,24 +11,24 @@
  */
 
 namespace Tedivm\StashBundle\Service;
+
 use Stash\Item;
 
 /**
- * Class CacheItem
- * @package Tedivm\StashBundle\Service
+ * Class CacheItem.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
 class CacheItem extends Item
 {
-
     /**
      * @var null|CacheTracker
      */
     protected $tracker;
 
     /**
-     * Enables tracking of hits. Typically called by Service Factory
+     * Enables tracking of hits. Typically called by Service Factory.
      *
      * @param CacheTracker $tracker
      */
@@ -52,5 +52,4 @@ class CacheItem extends Item
 
         return $result;
     }
-
 }

--- a/Service/CacheService.php
+++ b/Service/CacheService.php
@@ -11,19 +11,19 @@
  */
 
 namespace Tedivm\StashBundle\Service;
+
 use Stash\DriverList;
 use Stash\Interfaces\DriverInterface;
 use Stash\Pool;
 
 /**
- * Class CacheService
- * @package Tedivm\StashBundle\Service
+ * Class CacheService.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
 class CacheService extends Pool
 {
-
     /**
      * {@inheritdoc}
      */
@@ -47,7 +47,7 @@ class CacheService extends Pool
         $this->setNamespace($name);
 
         if (isset($driver)) {
-           $this->setDriver($driver);
+            $this->setDriver($driver);
         }
 
         parent::__construct($driver);
@@ -61,14 +61,15 @@ class CacheService extends Pool
         $args = func_get_args();
 
         // check to see if a single array was used instead of multiple arguments
-        if(count($args) == 1 && is_array($args[0]))
+        if (count($args) == 1 && is_array($args[0])) {
             $args = $args[0];
+        }
 
         /** @var CacheItem $item */
         $item = parent::getItem($args);
 
         if (isset($this->tracker)) {
-           $item->setCacheTracker($this->tracker);
+            $item->setCacheTracker($this->tracker);
         }
 
         return $item;

--- a/Service/CacheTracker.php
+++ b/Service/CacheTracker.php
@@ -13,8 +13,8 @@
 namespace Tedivm\StashBundle\Service;
 
 /**
- * Class CacheTracker
- * @package Tedivm\StashBundle\Service
+ * Class CacheTracker.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -70,7 +70,7 @@ class CacheTracker
     /**
      * Enables or disables query logging.
      *
-     * @param boolean $lq
+     * @param bool $lq
      */
     public function enableQueryLogging($lq = true)
     {
@@ -82,7 +82,7 @@ class CacheTracker
      *
      * @see $logQueryValues
      *
-     * @param boolean $logQueryValues
+     * @param bool $logQueryValues
      */
     public function enableQueryValueLogging($logQueryValues = true)
     {
@@ -98,9 +98,9 @@ class CacheTracker
      */
     public function trackRequest($key, $hit, $value)
     {
-        $this->calls++;
+        ++$this->calls;
         if ($hit) {
-            $this->hits++;
+            ++$this->hits;
         }
 
         if (!$this->logQueries) {
@@ -121,9 +121,9 @@ class CacheTracker
         }
 
         $this->queries[] = array(
-            'key'   => $key,
-            'hit'   => $hit,
-            'value' => $value
+            'key' => $key,
+            'hit' => $hit,
+            'value' => $value,
         );
     }
 

--- a/TedivmStashBundle.php
+++ b/TedivmStashBundle.php
@@ -12,7 +12,6 @@ use Tedivm\StashBundle\DependencyInjection\TedivmStashExtension;
  */
 class TedivmStashBundle extends Bundle
 {
-
     public function getContainerExtension()
     {
         return new TedivmStashExtension();

--- a/Tests/Adapters/DoctrineAdapterTest.php
+++ b/Tests/Adapters/DoctrineAdapterTest.php
@@ -19,8 +19,8 @@ use Tedivm\StashBundle\Adapters\DoctrineAdapter;
 use Tedivm\StashBundle\Tests\ThirdParty\Doctrine\CacheTest;
 
 /**
- * Class DoctrineAdapterTest
- * @package Tedivm\StashBundle\Tests\Adapters
+ * Class DoctrineAdapterTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -48,8 +48,8 @@ class DoctrineAdapterTest extends CacheTest
         $keys = array('memory_usage', 'memory_available', 'uptime', 'hits', 'misses');
 
         foreach ($keys as $key) {
-            $this->assertArrayHasKey($key, $stats, 'getStats has ' . $key . ' key even without tracker.');
-            $this->assertEquals('NA', $stats[$key], 'getStats returns NA for key ' . $key . ' without tracker.');
+            $this->assertArrayHasKey($key, $stats, 'getStats has '.$key.' key even without tracker.');
+            $this->assertEquals('NA', $stats[$key], 'getStats returns NA for key '.$key.' without tracker.');
         }
     }
 
@@ -88,12 +88,9 @@ class DoctrineAdapterTest extends CacheTest
 
     public function testDeleteAllAndNamespaceVersioningBetweenCaches()
     {
-
     }
 
     public function testFlushAllAndNamespaceVersioningBetweenCaches()
     {
-
     }
-
 }

--- a/Tests/Adapters/SessionHandlerAdapterTest.php
+++ b/Tests/Adapters/SessionHandlerAdapterTest.php
@@ -13,8 +13,8 @@
 namespace Tedivm\StashBundle\Tests\Adapters;
 
 /**
- * Class SessionHandlerAdapterTest
- * @package Tedivm\StashBundle\Tests\Adapters
+ * Class SessionHandlerAdapterTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -35,17 +35,17 @@ class SessionHandlerAdapterTest extends \Stash\Test\SessionTest
         $sessionA = $this->getSession($pool);
         $sessionA->open('save_path', 'sessionA');
         $sessionA->setOptions(array('ttl' => -30));
-        $sessionA->write('session_id', "session_a_data");
+        $sessionA->write('session_id', 'session_a_data');
 
         $sessionB = $this->getSession($pool);
         $sessionB->open('save_path', 'sessionB');
         $sessionB->setOptions(array('ttl' => -30));
-        $sessionB->write('session_id', "session_b_data");
+        $sessionB->write('session_id', 'session_b_data');
 
         $sessionC = $this->getSession($pool);
         $sessionC->open('save_path', 'sessionC');
         $sessionC->setOptions(array('ttl' => -30));
-        $sessionC->write('session_id', "session_c_data");
+        $sessionC->write('session_id', 'session_c_data');
 
         $sessionD = $this->getSession($pool);
         $sessionD->clearAll();
@@ -54,5 +54,4 @@ class SessionHandlerAdapterTest extends \Stash\Test\SessionTest
         $this->assertEquals('', $sessionB->read('session_id'), 'SessionB cleared after ClearAll');
         $this->assertEquals('', $sessionC->read('session_id'), 'SessionC cleared after ClearAll');
     }
-
 }

--- a/Tests/Collector/CacheDataCollectorTest.php
+++ b/Tests/Collector/CacheDataCollectorTest.php
@@ -12,12 +12,12 @@
 
 namespace Tedivm\StashBundle\Tests\Collector;
 
-use \Stash\DriverList;
-use \Tedivm\StashBundle\Service\CacheTracker as Tracker;
+use Stash\DriverList;
+use Tedivm\StashBundle\Service\CacheTracker as Tracker;
 
 /**
- * Class CacheDataCollectorTest
- * @package Tedivm\StashBundle\Tests\Collector
+ * Class CacheDataCollectorTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -26,9 +26,10 @@ class CacheDataCollectorTest extends \PHPUnit_Framework_TestCase
     protected $testClass = 'Tedivm\StashBundle\Collector\CacheDataCollector';
 
     /**
-     * @param  string                                           $cacheService
-     * @param  array                                            $caches
-     * @param  array                                            $options
+     * @param string $cacheService
+     * @param array  $caches
+     * @param array  $options
+     *
      * @return \Tedivm\StashBundle\Collector\CacheDataCollector
      */
     public function testConstruct($cacheService = 'default', $caches = array('default'), $options = array('default' => array()))
@@ -122,7 +123,7 @@ class CacheDataCollectorTest extends \PHPUnit_Framework_TestCase
         //var_dump($drivers, $systemDrivers);exit();
         foreach ($drivers as $driver) {
             $this->assertTrue(in_array($driver, $systemDrivers),
-                'getDrivers returns only registered drivers- Unregistered: ' . $driver);
+                'getDrivers returns only registered drivers- Unregistered: '.$driver);
         }
     }
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -16,8 +16,8 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Tedivm\StashBundle\DependencyInjection\Configuration;
 
 /**
- * Class ConfigurationTest
- * @package Tedivm\StashBundle\Tests\DependencyInjection
+ * Class ConfigurationTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -81,10 +81,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizeDefaultCacheConfig()
     {
-        $testData = array('caches' =>
-            array(  'Cache1' => 'TheCacheSettings',
+        $testData = array('caches' => array('Cache1' => 'TheCacheSettings',
                     'Cache2' => 'teTheCacheSettingsst',
-                    'Cache3' => 'teTheCacheSettingsst'));
+                    'Cache3' => 'teTheCacheSettingsst', ));
 
         $returnedData = Configuration::normalizeDefaultCacheConfig($testData);
 
@@ -95,7 +94,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testNormalizeHandlerToDriverConfig()
     {
-        $testData = array(  'handlers' => 'TheCacheSettings');
+        $testData = array('handlers' => 'TheCacheSettings');
 
         $returnedData = Configuration::normalizeHandlerToDriverConfig($testData);
 
@@ -103,5 +102,4 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('drivers', $returnedData, 'Normalization converts "handlers" to "drivers"');
         $this->assertEquals($testData['handlers'], $returnedData['drivers'], 'Normalization converts "handlers" to "drivers"');
     }
-
 }

--- a/Tests/DependencyInjection/TedivmStashExtensionTest.php
+++ b/Tests/DependencyInjection/TedivmStashExtensionTest.php
@@ -16,8 +16,8 @@ use Tedivm\StashBundle\DependencyInjection\TedivmStashExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Class TedivmStashExtensionTest
- * @package Tedivm\StashBundle\Tests\DependencyInjection
+ * Class TedivmStashExtensionTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -84,13 +84,13 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                         'first' => array(
                             'drivers' => array('FileSystem'),
                             'FileSystem' => array(
-                                'dirSplit'          => 2,
-                                'path'              => '%kernel.cache_dir%/stash',
-                                'filePermissions'   => 0660,
-                                'dirPermissions'    => 0770,
-                                'memKeyLimit'       => 400
+                                'dirSplit' => 2,
+                                'path' => '%kernel.cache_dir%/stash',
+                                'filePermissions' => 0660,
+                                'dirPermissions' => 0770,
+                                'memKeyLimit' => 400,
                             ),
-                        )
+                        ),
                     ),
                 ),
             ),
@@ -100,7 +100,7 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                     'default_cache' => 'first',
                     'caches' => array(
                         'first' => array(),
-                        )
+                        ),
                     ),
                 ),
 
@@ -115,9 +115,9 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                             'logger' => null,
                             'inMemory' => true,
                             'SQLite' => array(
-                                'filePermissions'   => 0550,
-                                'dirPermissions'    => 0444,
-                                'path'              => '%kernel.cache_dir%/tedivm/stash',
+                                'filePermissions' => 0550,
+                                'dirPermissions' => 0444,
+                                'path' => '%kernel.cache_dir%/tedivm/stash',
                             ),
                         ),
                         'nondefault' => array(
@@ -127,14 +127,14 @@ class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
                             'logger' => 'logger',
                             'inMemory' => true,
                             'FileSystem' => array(
-                                'filePermissions'   => 0770,
-                                'dirPermissions'    => 0666,
-                                'path'              => '/tmp/tedivm/stash',
+                                'filePermissions' => 0770,
+                                'dirPermissions' => 0666,
+                                'path' => '/tmp/tedivm/stash',
                             ),
                             'SQLite' => array(
-                                'filePermissions'   => 0777,
-                                'dirPermissions'    => 0666,
-                                'path'              => '%kernel.cache_dir%/tedivm/stash',
+                                'filePermissions' => 0777,
+                                'dirPermissions' => 0666,
+                                'path' => '%kernel.cache_dir%/tedivm/stash',
                             ),
                         ),
                     ),

--- a/Tests/Factory/DriverFactoryTest.php
+++ b/Tests/Factory/DriverFactoryTest.php
@@ -16,8 +16,8 @@ use Tedivm\StashBundle\Factory\DriverFactory;
 use Stash\DriverList;
 
 /**
- * Class DriverFactoryTest
- * @package Tedivm\StashBundle\Tests\Factory
+ * Class DriverFactoryTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -27,41 +27,41 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
 
     protected $defaultSettings = array(
         'FileSystem' => array(
-            'dirSplit'          => 2,
-            'filePermissions'   => 0660,
-            'dirPermissions'    => 0770,
-            'memKeyLimit'       => 200
+            'dirSplit' => 2,
+            'filePermissions' => 0660,
+            'dirPermissions' => 0770,
+            'memKeyLimit' => 200,
         ),
         'SQLite' => array(
-            'filePermissions'   => 0660,
-            'dirPermissions'    => 0770,
-            'busyTimeout'       => 500,
-            'nesting'           => 0,
-            'subdriver'        => 'PDO',
-            'version'           => null,
+            'filePermissions' => 0660,
+            'dirPermissions' => 0770,
+            'busyTimeout' => 500,
+            'nesting' => 0,
+            'subdriver' => 'PDO',
+            'version' => null,
         ),
         'Apc' => array(
-            'ttl'               => 300,
-            'namespace'         => null,
+            'ttl' => 300,
+            'namespace' => null,
         ),
         'Memcache' => array(
             'servers' => array(
                 array(
                     'server' => '127.0.0.1',
-                    'port' => '11211'
+                    'port' => '11211',
                 ),
                 array(
                     'server' => '127.0.0.1',
                     'port' => '11212',
-                    'weight' => '30'
+                    'weight' => '30',
                 ),
                 array(
                     'server' => '127.0.0.1',
                     'port' => '11211',
-                    'weight' => '30'
+                    'weight' => '30',
                 ),
-            )
-        )
+            ),
+        ),
     );
 
     public function setUp()
@@ -92,7 +92,6 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
             $subDriverClass = $this->drivers[$subtype];
             $this->assertInstanceOf($subDriverClass, $subDriver);
         }
-
     }
 
     public function testMemcacheSetup()
@@ -106,7 +105,6 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Driver does not exist.
      */
@@ -116,7 +114,6 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Driver currently unavailable.
      */
@@ -130,28 +127,28 @@ class DriverFactoryTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                'types'     => array('FileSystem'),
-                'options'   => array(),
+                'types' => array('FileSystem'),
+                'options' => array(),
             ),
             array(
-                'types'     => array('FileSystem'),
-                'options'   => array('FileSystem' => array('dirSplit' => 3, 'memKeyLimit' => 21)),
+                'types' => array('FileSystem'),
+                'options' => array('FileSystem' => array('dirSplit' => 3, 'memKeyLimit' => 21)),
             ),
             array(
-                'types'     => array('SQLite'),
-                'options'   => array(),
+                'types' => array('SQLite'),
+                'options' => array(),
             ),
             array(
-                'types'     => array('SQLite'),
-                'options'   => array('nesting' => 2, 'extension' => 'sqlite'),
+                'types' => array('SQLite'),
+                'options' => array('nesting' => 2, 'extension' => 'sqlite'),
             ),
             array(
-                'types'     => array('Ephemeral', 'FileSystem'),
-                'options'   => array('FileSystem' => array('dirSplit' => 2)),
+                'types' => array('Ephemeral', 'FileSystem'),
+                'options' => array('FileSystem' => array('dirSplit' => 2)),
             ),
             array(
-                'types'     => array('Ephemeral', 'FileSystem', 'SQLite'),
-                'options'   => array('FileSystem' => array('dirSplit' => 3), 'SQLite' => array('dirSplit' => 5)),
+                'types' => array('Ephemeral', 'FileSystem', 'SQLite'),
+                'options' => array('FileSystem' => array('dirSplit' => 3), 'SQLite' => array('dirSplit' => 5)),
             ),
         );
     }

--- a/Tests/Service/CacheItemTest.php
+++ b/Tests/Service/CacheItemTest.php
@@ -15,8 +15,8 @@ namespace Tedivm\StashBundle\Tests\Service;
 use Tedivm\StashBundle\Service\CacheTracker;
 
 /**
- * Class CacheItemTest
- * @package Tedivm\StashBundle\Tests\Service
+ * Class CacheItemTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */

--- a/Tests/Service/CacheServiceTest.php
+++ b/Tests/Service/CacheServiceTest.php
@@ -12,14 +12,13 @@
 
 namespace Tedivm\StashBundle\Tests\Service;
 
-use Tedivm\StashBundle\Service\CacheService;
 use Tedivm\StashBundle\Service\CacheTracker;
 use Stash\Driver\Ephemeral;
 use Stash\DriverList;
 
 /**
- * Class CacheServiceTest
- * @package Tedivm\StashBundle\Tests\Service
+ * Class CacheServiceTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -141,7 +140,7 @@ class CacheServiceTest extends \Stash\Test\AbstractPoolTest
     protected function runCacheCycle($service, $num, $ismiss)
     {
         $key = array('test', 'key', $num);
-        $testData = 'testkey' . $num;
+        $testData = 'testkey'.$num;
 
         $item = $service->getItem($key);
         $data = $item->get();
@@ -154,5 +153,4 @@ class CacheServiceTest extends \Stash\Test\AbstractPoolTest
         $this->assertFalse($item->isMiss());
         $this->assertEquals($testData, $data);
     }
-
 }

--- a/Tests/Service/CacheTrackerTest.php
+++ b/Tests/Service/CacheTrackerTest.php
@@ -13,15 +13,15 @@
 namespace Tedivm\StashBundle\Tests\Service;
 
 /**
- * Class CacheTrackerTest
- * @package Tedivm\StashBundle\Tests\Service
+ * Class CacheTrackerTest.
  */
 class CacheTrackerTest extends \PHPUnit_Framework_TestCase
 {
     protected $testClass = '\Tedivm\StashBundle\Service\CacheTracker';
 
     /**
-     * @param  string                                     $name
+     * @param string $name
+     *
      * @return '\Tedivm\StashBundle\Service\CacheTracker'
      */
     public function testConstruct($name = 'test')
@@ -34,7 +34,6 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
 
     public function testTrackRequest()
     {
-
     }
 
     public function testGetName()
@@ -59,7 +58,6 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
         $tracker->trackRequest('Key7', false, 'Value7');
 
         $this->assertEquals(8, $tracker->getCalls(), 'Tracker counts calls sent to it with duplicate keys.');
-
     }
 
     public function testGetHits()
@@ -75,7 +73,6 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
         $tracker->trackRequest('Key7', true, 'Value7');
 
         $this->assertEquals(4, $tracker->getHits(), 'Tracker increments hits when sent them.');
-
     }
 
     public function testGetQueries()
@@ -94,9 +91,9 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
         foreach ($data as $index => $datum) {
             $query = $queries[$index];
             $expectedTruth = $datum[1] ? 'true' : 'false';
-            $this->assertEquals($datum[0], $query['key'], 'getQueries returns key for data example ' . $index);
-            $this->assertEquals($expectedTruth, $query['hit'], 'getQueries returns hit status as string for data example ' . $index);
-            $this->assertEquals($datum[3], $query['value'], 'getQueries returns value for data example ' . $index);
+            $this->assertEquals($datum[0], $query['key'], 'getQueries returns key for data example '.$index);
+            $this->assertEquals($expectedTruth, $query['hit'], 'getQueries returns hit status as string for data example '.$index);
+            $this->assertEquals($datum[3], $query['value'], 'getQueries returns value for data example '.$index);
         }
 
         $tracker = $this->testConstruct('unpopulated');
@@ -124,10 +121,10 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
         foreach ($data as $index => $datum) {
             $query = $queries[$index];
             $expectedTruth = $datum[1] ? 'true' : 'false';
-            $expectedValue = explode(" ", $datum[3], 2)[0];
-            $this->assertEquals($datum[0], $query['key'], 'getQueries returns key for data example ' . $index);
-            $this->assertEquals($expectedTruth, $query['hit'], 'getQueries returns hit status as string for data example ' . $index);
-            $this->assertEquals($expectedValue, $query['value'], 'getQueries returns value for data example ' . $index);
+            $expectedValue = explode(' ', $datum[3], 2)[0];
+            $this->assertEquals($datum[0], $query['key'], 'getQueries returns key for data example '.$index);
+            $this->assertEquals($expectedTruth, $query['hit'], 'getQueries returns hit status as string for data example '.$index);
+            $this->assertEquals($expectedValue, $query['value'], 'getQueries returns value for data example '.$index);
         }
     }
 
@@ -151,7 +148,7 @@ class CacheTrackerTest extends \PHPUnit_Framework_TestCase
             array('Key1', true, 'Value1', '(string) Value1'),
             array('Key2', false, 2, '(integer) 2'),
             array('Key3', true, array(), "(array) Array\n(\n)\n"),
-            array('Key4', false, new \stdClass(), "(object) ".serialize(new \stdClass())),
+            array('Key4', false, new \stdClass(), '(object) '.serialize(new \stdClass())),
             array('Key5', true, 'Value5', '(string) Value5'),
             array('Key6', false, 'Value6', '(string) Value6'),
         );

--- a/Tests/TedivmStashBundleTest.php
+++ b/Tests/TedivmStashBundleTest.php
@@ -13,8 +13,8 @@
 namespace Tedivm\StashBundle\Tests;
 
 /**
- * Class TedivmStashBundleTest
- * @package Tedivm\StashBundle\Tests
+ * Class TedivmStashBundleTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */

--- a/Tests/ThirdParty/Doctrine/CacheTest.php
+++ b/Tests/ThirdParty/Doctrine/CacheTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * This test was copied and modified from the DoctrineCache project.
  *
  * Copyright (c) 2006-2012 Doctrine Project
@@ -30,8 +29,8 @@ use Doctrine\Common\Cache\Cache;
 use ArrayObject;
 
 /**
- * Class CacheTest
- * @package Tedivm\StashBundle\Tests\ThirdParty\Doctrine
+ * Class CacheTest.
+ *
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
@@ -83,8 +82,8 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteAllAndNamespaceVersioningBetweenCaches()
     {
-        if ( ! $this->isSharedStorage()) {
-            $this->markTestSkipped('The ' . __CLASS__ .' does not use shared storage');
+        if (!$this->isSharedStorage()) {
+            $this->markTestSkipped('The '.__CLASS__.' does not use shared storage');
         }
 
         $cache1 = $this->_getCacheDriver();
@@ -133,8 +132,8 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
 
     public function testFlushAllAndNamespaceVersioningBetweenCaches()
     {
-        if ( ! $this->isSharedStorage()) {
-            $this->markTestSkipped('The ' . __CLASS__ .' does not use shared storage');
+        if (!$this->isSharedStorage()) {
+            $this->markTestSkipped('The '.__CLASS__.' does not use shared storage');
         }
 
         $cache1 = $this->_getCacheDriver();
@@ -257,7 +256,7 @@ abstract class CacheTest extends \PHPUnit_Framework_TestCase
      *
      * This is used for skipping certain tests for shared storage behavior.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isSharedStorage()
     {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -16,16 +16,16 @@ error_reporting(-1);
 
 date_default_timezone_set('UTC');
 
-$filename = __DIR__ .'/../vendor/autoload.php';
+$filename = __DIR__.'/../vendor/autoload.php';
 
 if (!file_exists($filename)) {
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" . PHP_EOL;
-    echo " You need to execute `composer install` before running the tests. " . PHP_EOL;
-    echo "         Vendors are required for complete test execution.        " . PHP_EOL;
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" . PHP_EOL . PHP_EOL;
-    $filename = __DIR__ .'/../autoload.php';
+    echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'.PHP_EOL;
+    echo ' You need to execute `composer install` before running the tests. '.PHP_EOL;
+    echo '         Vendors are required for complete test execution.        '.PHP_EOL;
+    echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'.PHP_EOL.PHP_EOL;
+    $filename = __DIR__.'/../autoload.php';
 }
 
 $loader = require $filename;
 $loader->addPsr4('Tedivm\\StashBundle\\Test\\', __DIR__);
-$loader->addPsr4('Stash\\Test\\', __DIR__ . '/../vendor/tedivm/stash/tests/Stash/Test/');
+$loader->addPsr4('Stash\\Test\\', __DIR__.'/../vendor/tedivm/stash/tests/Stash/Test/');

--- a/Tests/runTests.sh
+++ b/Tests/runTests.sh
@@ -13,4 +13,4 @@ echo ''
 echo ''
 echo 'Testing for Coding Styling Compliance.'
 echo 'All code should follow PSR standards.'
-./vendor/fabpot/php-cs-fixer/php-cs-fixer fix ./ --level="all" -vv --dry-run
+./vendor/bin/php-cs-fixer fix ./ -vv --dry-run

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         "symfony/dependency-injection": "~2.1|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
-        "fabpot/php-cs-fixer": "0.4.0",
-        "satooshi/php-coveralls": "1.0.*",
+        "phpunit/phpunit": "^4.7",
+        "fabpot/php-cs-fixer": "^1.9",
+        "satooshi/php-coveralls": "^1.0",
         "doctrine/cache": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
To make sure only Symfony 3.x Components are used for tests on PHP 5.5 and higher we need to update dev dependencies *(2.x is used on PHP 5.4, so both 2.8 and 3.0 is hence tested)*.

##### State:
Remaining component pulled in from Symfony 2.x: `symfony/event-dispatcher (v2.8.1)`. Unsure what is doing this, but assuming it is done upstream somewhere that will eventually be fixed.

- [ ] Fix cs issues reported by newer version of php-cs-fixer *(different results on run locally vs on travis..)*