### PR TITLE
More meaningful error message

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -120,7 +120,7 @@ class Configuration implements ConfigurationInterface
             ->prototype('scalar')
             ->validate()
             ->ifNotInArray($drivers)
-            ->thenInvalid('A driver of that name is not registered.')
+            ->thenInvalid('A driver of name %s is not registered.')
             ->end()
             ->end()
             ->end()


### PR DESCRIPTION
As an example, this might output
```
A driver of name "SQlite" is not registered.
```
instead of
```
A driver of that name is not registered.
```