### PR TITLE
Fix case-sensitive driver key in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ FileSystem:
     filePermissions:        0660
     dirPermissions:         0770
     memKeyLimit:            20
-Sqlite:
+SQLite:
     path:                   %kernel.cache_dir%/stash
     filePermissions:        0660
     dirPermissions:         0770
@@ -264,3 +264,4 @@ Memcache:
     servers:
         - { server: 127.0.0.1, port: 11211, weight: 1 }
 ```
+


### PR DESCRIPTION
The following code

```yaml
stash:
  drivers: [ Sqlite ]
```

will lead to error

```
A driver of name "Sqlite" is not registered.
```

as it's checked against the case-sensitive list from https://github.com/tedious/Stash/blob/11cc82d09412ee59dbb46262649d67d19eb06b4c/src/Stash/DriverList.php#L34:

```php
protected static $drivers = array('Apc' => '\Stash\Driver\Apc',
                                  'BlackHole' => '\Stash\Driver\BlackHole',
                                  'Composite' => '\Stash\Driver\Composite',
                                  'Ephemeral' => '\Stash\Driver\Ephemeral',
                                  'FileSystem' => '\Stash\Driver\FileSystem',
                                  'Memcache' => '\Stash\Driver\Memcache',
                                  'Redis' => '\Stash\Driver\Redis',
                                  'SQLite' => '\Stash\Driver\Sqlite',
);
```

The documentation is therefore misleading.