### PR TITLE
Patch Item TTL

### DIFF
--- a/Adapters/DoctrineAdapter.php
+++ b/Adapters/DoctrineAdapter.php
@@ -107,7 +107,8 @@ class DoctrineAdapter implements DoctrineCacheInterface
 
         $id = $this->normalizeId($id);
         $item = $this->cacheService->getItem($id);
-        $item->set($data, $lifeTime);
+        $item->set($data);
+        $item->setTTL($lifeTime);
 
         return $this->cacheService->save($item);
     }


### PR DESCRIPTION
The method `set()` called in `$item->set($data, $lifeTime);` does not take a second argument. See https://github.com/tedious/Stash/blob/master/src/Stash/Interfaces/ItemInterface.php#L103.