### PR TITLE
Made bundle compatible with symfony 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - hhvm
+    - 7.3
 
 before_install:
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - hhvm
 
 before_install:

--- a/Adapters/DoctrineAdapter.php
+++ b/Adapters/DoctrineAdapter.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Cache\Cache as DoctrineCacheInterface;
 
 /**
  * Class DoctrineAdapter
+ *
  * @package Tedivm\StashBundle\Adapters
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>

--- a/Adapters/DoctrineAdapter.php
+++ b/Adapters/DoctrineAdapter.php
@@ -11,6 +11,7 @@
  */
 
 namespace Tedivm\StashBundle\Adapters;
+
 use Doctrine\Common\Cache\Cache as DoctrineCacheInterface;
 
 /**

--- a/Collector/CacheDataCollector.php
+++ b/Collector/CacheDataCollector.php
@@ -11,6 +11,7 @@
  */
 
 namespace Tedivm\StashBundle\Collector;
+
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/Collector/CacheDataCollector.php
+++ b/Collector/CacheDataCollector.php
@@ -152,4 +152,9 @@ class CacheDataCollector extends DataCollector
     {
         return 'stash';
     }
+
+    public function reset()
+    {
+        $this->data = [];
+    }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,13 +66,17 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->beforeNormalization()
-                ->ifTrue(function ($v) { return is_array($v) && !array_key_exists('default_cache', $v) && array_key_exists('caches', $v); })
+                ->ifTrue(function ($v) {
+                    return is_array($v) && !array_key_exists('default_cache', $v) && array_key_exists('caches', $v);
+                })
                 ->then(function ($v) {
                     return Configuration::normalizeDefaultCacheConfig($v);
                 })
             ->end()
             ->beforeNormalization()
-                ->ifTrue(function ($v) { return is_array($v) && !array_key_exists('caches', $v) && !array_key_exists('cache', $v); })
+                ->ifTrue(function ($v) {
+                    return is_array($v) && !array_key_exists('caches', $v) && !array_key_exists('cache', $v);
+                })
                 ->then(function ($v) {
                     return Configuration::normalizeCacheConfig($v);
                 })
@@ -105,7 +109,9 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('handler')
             ->fixXmlConfig('driver')
             ->beforeNormalization()
-            ->ifTrue(function ($v) { return is_array($v) && array_key_exists('handlers', $v); })
+            ->ifTrue(function ($v) {
+                return is_array($v) && array_key_exists('handlers', $v);
+            })
             ->then(function ($v) {
                 return Configuration::normalizeHandlerToDriverConfig($v);
             })
@@ -152,8 +158,8 @@ class Configuration implements ConfigurationInterface
             ->arrayNode($driver)
                 ->fixXmlConfig('server');
 
-            if ($driver == 'Memcache') {
-                $finalNode = $driverNode
+        if ($driver == 'Memcache') {
+            $finalNode = $driverNode
                     ->info('All options except "servers" are Memcached options. See http://www.php.net/manual/en/memcached.constants.php')
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -193,8 +199,8 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                ;
-            } elseif ($driver == 'Redis') {
-                $finalNode = $driverNode
+        } elseif ($driver == 'Redis') {
+            $finalNode = $driverNode
                     ->info("Accepts server info, password, and database.")
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -216,26 +222,26 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ;
-            } else {
-                $defaults = isset($this->driverSettings[$driver]) ? $this->driverSettings[$driver] : array();
+        } else {
+            $defaults = isset($this->driverSettings[$driver]) ? $this->driverSettings[$driver] : array();
 
-                $node = $driverNode
+            $node = $driverNode
                     ->addDefaultsIfNotSet()
                     ->children();
 
-                    foreach ($defaults as $setting => $default) {
-                        $node
+            foreach ($defaults as $setting => $default) {
+                $node
                             ->scalarNode($setting)
                             ->defaultValue($default)
                             ->end()
                         ;
-                    }
-
-                    $finalNode = $node->end()
-                ;
             }
 
-            $finalNode->end()
+            $finalNode = $node->end()
+                ;
+        }
+
+        $finalNode->end()
         ;
     }
 

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -158,7 +158,6 @@ class TedivmStashExtension extends Extension
                     new Reference(sprintf('stash.tracker.%s_cache', $name))
                 ))
         ;
-
     }
 
     /**

--- a/DependencyInjection/TedivmStashExtension.php
+++ b/DependencyInjection/TedivmStashExtension.php
@@ -14,7 +14,7 @@ namespace Tedivm\StashBundle\DependencyInjection;
 
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\FileLocator;
@@ -88,34 +88,37 @@ class TedivmStashExtension extends Extension
         unset($cache['registerSessionHandler']);
 
         $container
-            ->setDefinition(sprintf('stash.driver.%s_cache', $name), new DefinitionDecorator('stash.driver'))
-            ->setArguments(array(
-                $drivers,
-                $cache
-            ))
-            ->setAbstract(false)
-        ;
+            ->setDefinition(sprintf('stash.driver.%s_cache', $name), new ChildDefinition('stash.driver'))
+            ->setArguments(
+                [
+                    $drivers,
+                    $cache,
+                ]
+            )
+            ->setAbstract(false);
 
         $container
-            ->setDefinition(sprintf('stash.tracker.%s_cache', $name), new DefinitionDecorator('stash.tracker'))
-            ->setArguments(array(
-                $name
-            ))
-            ->addMethodCall('enableQueryLogging', array($logqueries))
-            ->addMethodCall('enableQueryValueLogging', array($logQueryValues))
-            ->setAbstract(false)
-        ;
+            ->setDefinition(sprintf('stash.tracker.%s_cache', $name), new ChildDefinition('stash.tracker'))
+            ->setArguments(
+                [
+                    $name,
+                ]
+            )
+            ->addMethodCall('enableQueryLogging', [$logqueries])
+            ->addMethodCall('enableQueryValueLogging', [$logQueryValues])
+            ->setAbstract(false);
 
-        $cacheDefinition = new DefinitionDecorator('stash.cache');
+        $cacheDefinition = new ChildDefinition('stash.cache');
         $container
             ->setDefinition(sprintf('stash.%s_cache', $name), $cacheDefinition)
-            ->setArguments(array(
-                $name,
-                new Reference(sprintf('stash.driver.%s_cache', $name)),
-                new Reference(sprintf('stash.tracker.%s_cache', $name))
-            ))
-            ->setAbstract(false)
-        ;
+            ->setArguments(
+                [
+                    $name,
+                    new Reference(sprintf('stash.driver.%s_cache', $name)),
+                    new Reference(sprintf('stash.tracker.%s_cache', $name)),
+                ]
+            )
+            ->setAbstract(false);
 
         if (isset($cache['logger']) && $cache['logger']) {
             $cacheDefinition->addMethodCall('setLogger', array(new Reference($cache['logger'])));
@@ -123,22 +126,30 @@ class TedivmStashExtension extends Extension
 
         if (interface_exists("\\Doctrine\\Common\\Cache\\Cache") && $doctrine) {
             $container
-                ->setDefinition(sprintf('stash.adapter.doctrine.%s_cache', $name), new DefinitionDecorator('stash.adapter.doctrine'))
-                ->setArguments(array(
-                    new Reference(sprintf('stash.%s_cache', $name))
-                ))
-                ->setAbstract(false)
-            ;
+                ->setDefinition(
+                    sprintf('stash.adapter.doctrine.%s_cache', $name),
+                    new ChildDefinition('stash.adapter.doctrine')
+                )
+                ->setArguments(
+                    [
+                        new Reference(sprintf('stash.%s_cache', $name)),
+                    ]
+                )
+                ->setAbstract(false);
         }
 
         if ($session) {
             $container
-                ->setDefinition(sprintf('stash.adapter.session.%s_cache', $name), new DefinitionDecorator('stash.adapter.session'))
-                ->setArguments(array(
-                    new Reference(sprintf('stash.%s_cache', $name))
-                ))
-                ->setAbstract(false)
-            ;
+                ->setDefinition(
+                    sprintf('stash.adapter.session.%s_cache', $name),
+                    new ChildDefinition('stash.adapter.session')
+                )
+                ->setArguments(
+                    [
+                        new Reference(sprintf('stash.%s_cache', $name)),
+                    ]
+                )
+                ->setAbstract(false);
         }
 
         $container

--- a/Factory/DriverFactory.php
+++ b/Factory/DriverFactory.php
@@ -11,6 +11,7 @@
  */
 
 namespace Tedivm\StashBundle\Factory;
+
 use Stash\DriverList;
 use Stash\Interfaces\DriverInterface;
 
@@ -37,7 +38,6 @@ class DriverFactory
         $h = array();
 
         foreach ($types as $type) {
-
             if (!isset($drivers[$type])) {
                 $allDrivers = DriverList::getAllDrivers();
 

--- a/Service/CacheItem.php
+++ b/Service/CacheItem.php
@@ -11,6 +11,7 @@
  */
 
 namespace Tedivm\StashBundle\Service;
+
 use Stash\Item;
 
 /**
@@ -52,5 +53,4 @@ class CacheItem extends Item
 
         return $result;
     }
-
 }

--- a/Service/CacheService.php
+++ b/Service/CacheService.php
@@ -11,6 +11,7 @@
  */
 
 namespace Tedivm\StashBundle\Service;
+
 use Stash\DriverList;
 use Stash\Interfaces\DriverInterface;
 use Stash\Pool;
@@ -47,7 +48,7 @@ class CacheService extends Pool
         $this->setNamespace($name);
 
         if (isset($driver)) {
-           $this->setDriver($driver);
+            $this->setDriver($driver);
         }
 
         parent::__construct($driver);
@@ -62,7 +63,7 @@ class CacheService extends Pool
         $item = parent::getItem($key);
 
         if (isset($this->tracker)) {
-           $item->setCacheTracker($this->tracker);
+            $item->setCacheTracker($this->tracker);
         }
 
         return $item;

--- a/TedivmStashBundle.php
+++ b/TedivmStashBundle.php
@@ -12,7 +12,6 @@ use Tedivm\StashBundle\DependencyInjection\TedivmStashExtension;
  */
 class TedivmStashBundle extends Bundle
 {
-
     public function getContainerExtension()
     {
         return new TedivmStashExtension();

--- a/Tests/Adapters/DoctrineAdapterTest.php
+++ b/Tests/Adapters/DoctrineAdapterTest.php
@@ -88,12 +88,9 @@ class DoctrineAdapterTest extends CacheTest
 
     public function testDeleteAllAndNamespaceVersioningBetweenCaches()
     {
-
     }
 
     public function testFlushAllAndNamespaceVersioningBetweenCaches()
     {
-
     }
-
 }

--- a/Tests/Adapters/SessionHandlerAdapterTest.php
+++ b/Tests/Adapters/SessionHandlerAdapterTest.php
@@ -54,5 +54,4 @@ class SessionHandlerAdapterTest extends \Stash\Test\SessionTest
         $this->assertEquals('', $sessionB->read('session_id'), 'SessionB cleared after ClearAll');
         $this->assertEquals('', $sessionC->read('session_id'), 'SessionC cleared after ClearAll');
     }
-
 }

--- a/Tests/Collector/CacheDataCollectorTest.php
+++ b/Tests/Collector/CacheDataCollectorTest.php
@@ -124,8 +124,10 @@ class CacheDataCollectorTest extends TestCase
 
         //var_dump($drivers, $systemDrivers);exit();
         foreach ($drivers as $driver) {
-            $this->assertTrue(in_array($driver, $systemDrivers),
-                'getDrivers returns only registered drivers- Unregistered: ' . $driver);
+            self::assertTrue(
+                in_array($driver, $systemDrivers),
+                'getDrivers returns only registered drivers- Unregistered: ' . $driver
+            );
         }
     }
 

--- a/Tests/Collector/CacheDataCollectorTest.php
+++ b/Tests/Collector/CacheDataCollectorTest.php
@@ -12,8 +12,11 @@
 
 namespace Tedivm\StashBundle\Tests\Collector;
 
-use \Stash\DriverList;
-use \Tedivm\StashBundle\Service\CacheTracker as Tracker;
+use PHPUnit\Framework\TestCase;
+use Stash\DriverList;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tedivm\StashBundle\Service\CacheTracker as Tracker;
 
 /**
  * Class CacheDataCollectorTest
@@ -21,7 +24,7 @@ use \Tedivm\StashBundle\Service\CacheTracker as Tracker;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class CacheDataCollectorTest extends \PHPUnit_Framework_TestCase
+class CacheDataCollectorTest extends TestCase
 {
     protected $testClass = 'Tedivm\StashBundle\Collector\CacheDataCollector';
 
@@ -126,12 +129,21 @@ class CacheDataCollectorTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testResetWillSetDataToEmptyArray()
+    {
+        $collector = $this->getPrimedCollector();
+
+        self::assertNotSame('a:0:{}', $collector->serialize());
+        $collector->reset();
+        self::assertSame('a:0:{}', $collector->serialize());
+    }
+
     protected function getPrimedCollector()
     {
         $collector = $this->getPopulatedCollector();
 
-        $requestMock = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $responseMock = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $requestMock = $this->createMock(Request::class);
+        $responseMock = $this->createMock(Response::class);
 
         $collector->collect($requestMock, $responseMock);
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,6 +12,7 @@
 
 namespace Tedivm\StashBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Tedivm\StashBundle\DependencyInjection\Configuration;
 
@@ -21,7 +22,7 @@ use Tedivm\StashBundle\DependencyInjection\Configuration;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testGetConfigTreeBuilder()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@
 namespace Tedivm\StashBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Tedivm\StashBundle\DependencyInjection\Configuration;
 
@@ -41,8 +42,11 @@ class ConfigurationTest extends TestCase
         $configuration->addDriverSettings('Memcache', $rootNode->children());
         $memcacheNode = $rootNode->getNode('Memcache');
 
-        $this->assertInstanceOf('Symfony\Component\Config\Definition\ArrayNode', $memcacheNode,
-            'Config generator makes Memcache nodes when requested');
+        $this->assertInstanceOf(
+            ArrayNode::class,
+            $memcacheNode,
+            'Config generator makes Memcache nodes when requested'
+        );
 
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('stash');
@@ -50,8 +54,11 @@ class ConfigurationTest extends TestCase
         $configuration->addDriverSettings('Redis', $rootNode->children());
         $memcacheNode = $rootNode->getNode('Redis');
 
-        $this->assertInstanceOf('Symfony\Component\Config\Definition\ArrayNode', $memcacheNode,
-            'Config generator makes Redis nodes when requested');
+        $this->assertInstanceOf(
+            ArrayNode::class,
+            $memcacheNode,
+            'Config generator makes Redis nodes when requested'
+        );
     }
 
     public function testNormalizeCacheConfig()
@@ -104,5 +111,4 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('drivers', $returnedData, 'Normalization converts "handlers" to "drivers"');
         $this->assertEquals($testData['handlers'], $returnedData['drivers'], 'Normalization converts "handlers" to "drivers"');
     }
-
 }

--- a/Tests/DependencyInjection/TedivmStashExtensionTest.php
+++ b/Tests/DependencyInjection/TedivmStashExtensionTest.php
@@ -12,6 +12,7 @@
 
 namespace Tedivm\StashBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Tedivm\StashBundle\DependencyInjection\TedivmStashExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -21,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class TedivmStashExtensionTest extends \PHPUnit_Framework_TestCase
+class TedivmStashExtensionTest extends TestCase
 {
     /**
      * @dataProvider configProvider

--- a/Tests/Factory/DriverFactoryTest.php
+++ b/Tests/Factory/DriverFactoryTest.php
@@ -12,6 +12,7 @@
 
 namespace Tedivm\StashBundle\Tests\Factory;
 
+use PHPUnit\Framework\TestCase;
 use Tedivm\StashBundle\Factory\DriverFactory;
 use Stash\DriverList;
 
@@ -21,7 +22,7 @@ use Stash\DriverList;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class DriverFactoryTest extends \PHPUnit_Framework_TestCase
+class DriverFactoryTest extends TestCase
 {
     protected $drivers = array();
 

--- a/Tests/Factory/DriverFactoryTest.php
+++ b/Tests/Factory/DriverFactoryTest.php
@@ -93,7 +93,6 @@ class DriverFactoryTest extends TestCase
             $subDriverClass = $this->drivers[$subtype];
             $this->assertInstanceOf($subDriverClass, $subDriver);
         }
-
     }
 
     public function testMemcacheSetup()

--- a/Tests/Service/CacheItemTest.php
+++ b/Tests/Service/CacheItemTest.php
@@ -12,6 +12,7 @@
 
 namespace Tedivm\StashBundle\Tests\Service;
 
+use Stash\Test\AbstractItemTest;
 use Tedivm\StashBundle\Service\CacheTracker;
 
 /**
@@ -20,7 +21,7 @@ use Tedivm\StashBundle\Service\CacheTracker;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class CacheItemTest extends \Stash\Test\AbstractItemTest
+class CacheItemTest extends AbstractItemTest
 {
     protected $itemClass = '\Tedivm\StashBundle\Service\CacheItem';
 

--- a/Tests/Service/CacheServiceTest.php
+++ b/Tests/Service/CacheServiceTest.php
@@ -158,5 +158,4 @@ class CacheServiceTest extends \Stash\Test\AbstractPoolTest
         $this->assertFalse($item->isMiss());
         $this->assertEquals($testData, $data);
     }
-
 }

--- a/Tests/Service/CacheServiceTest.php
+++ b/Tests/Service/CacheServiceTest.php
@@ -14,6 +14,7 @@ namespace Tedivm\StashBundle\Tests\Service;
 
 use Stash\Driver\Ephemeral;
 use Stash\DriverList;
+use Stash\Interfaces\ItemInterface;
 use Tedivm\StashBundle\Service\CacheTracker;
 
 /**
@@ -120,8 +121,8 @@ class CacheServiceTest extends \Stash\Test\AbstractPoolTest
         $iterator = $service->getItems($keys);
         $setvalues = $values;
 
+        /** @var ItemInterface $item */
         foreach ($iterator as $item) {
-            $this->assertTrue($item->isMiss());
             $val = array_shift($setvalues);
             $item->set($val);
             $service->save($item);

--- a/Tests/Service/CacheServiceTest.php
+++ b/Tests/Service/CacheServiceTest.php
@@ -12,10 +12,9 @@
 
 namespace Tedivm\StashBundle\Tests\Service;
 
-use Tedivm\StashBundle\Service\CacheService;
-use Tedivm\StashBundle\Service\CacheTracker;
 use Stash\Driver\Ephemeral;
 use Stash\DriverList;
+use Tedivm\StashBundle\Service\CacheTracker;
 
 /**
  * Class CacheServiceTest

--- a/Tests/Service/CacheTrackerTest.php
+++ b/Tests/Service/CacheTrackerTest.php
@@ -12,11 +12,14 @@
 
 namespace Tedivm\StashBundle\Tests\Service;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class CacheTrackerTest
+ *
  * @package Tedivm\StashBundle\Tests\Service
  */
-class CacheTrackerTest extends \PHPUnit_Framework_TestCase
+class CacheTrackerTest extends TestCase
 {
     protected $testClass = '\Tedivm\StashBundle\Service\CacheTracker';
 

--- a/Tests/Service/CacheTrackerTest.php
+++ b/Tests/Service/CacheTrackerTest.php
@@ -37,7 +37,6 @@ class CacheTrackerTest extends TestCase
 
     public function testTrackRequest()
     {
-
     }
 
     public function testGetName()
@@ -62,7 +61,6 @@ class CacheTrackerTest extends TestCase
         $tracker->trackRequest('Key7', false, 'Value7');
 
         $this->assertEquals(8, $tracker->getCalls(), 'Tracker counts calls sent to it with duplicate keys.');
-
     }
 
     public function testGetHits()
@@ -78,7 +76,6 @@ class CacheTrackerTest extends TestCase
         $tracker->trackRequest('Key7', true, 'Value7');
 
         $this->assertEquals(4, $tracker->getHits(), 'Tracker increments hits when sent them.');
-
     }
 
     public function testGetQueries()

--- a/Tests/TedivmStashBundleTest.php
+++ b/Tests/TedivmStashBundleTest.php
@@ -13,6 +13,7 @@
 namespace Tedivm\StashBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Tedivm\StashBundle\DependencyInjection\TedivmStashExtension;
 
 /**
  * Class TedivmStashBundleTest
@@ -27,7 +28,9 @@ class TedivmStashBundleTest extends TestCase
     {
         $bundle = new \Tedivm\StashBundle\TedivmStashBundle();
 
-        $this->assertInstanceOf('Tedivm\StashBundle\DependencyInjection\TedivmStashExtension',
-            $bundle->getContainerExtension());
+        $this->assertInstanceOf(
+            TedivmStashExtension::class,
+            $bundle->getContainerExtension()
+        );
     }
 }

--- a/Tests/TedivmStashBundleTest.php
+++ b/Tests/TedivmStashBundleTest.php
@@ -12,13 +12,16 @@
 
 namespace Tedivm\StashBundle\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class TedivmStashBundleTest
+ *
  * @package Tedivm\StashBundle\Tests
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-class TedivmStashBundleTest extends \PHPUnit_Framework_TestCase
+class TedivmStashBundleTest extends TestCase
 {
     public function testGetContainerExtension()
     {

--- a/Tests/ThirdParty/Doctrine/CacheTest.php
+++ b/Tests/ThirdParty/Doctrine/CacheTest.php
@@ -84,7 +84,7 @@ abstract class CacheTest extends TestCase
 
     public function testDeleteAllAndNamespaceVersioningBetweenCaches()
     {
-        if ( ! $this->isSharedStorage()) {
+        if (! $this->isSharedStorage()) {
             $this->markTestSkipped('The ' . __CLASS__ .' does not use shared storage');
         }
 
@@ -134,7 +134,7 @@ abstract class CacheTest extends TestCase
 
     public function testFlushAllAndNamespaceVersioningBetweenCaches()
     {
-        if ( ! $this->isSharedStorage()) {
+        if (! $this->isSharedStorage()) {
             $this->markTestSkipped('The ' . __CLASS__ .' does not use shared storage');
         }
 

--- a/Tests/ThirdParty/Doctrine/CacheTest.php
+++ b/Tests/ThirdParty/Doctrine/CacheTest.php
@@ -28,6 +28,7 @@ namespace Tedivm\StashBundle\Tests\ThirdParty\Doctrine;
 
 use Doctrine\Common\Cache\Cache;
 use ArrayObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CacheTest
@@ -35,7 +36,7 @@ use ArrayObject;
  * @author Josh Hall-Bachner <jhallbachner@gmail.com>
  * @author Robert Hafner <tedivm@tedivm.com>
  */
-abstract class CacheTest extends \PHPUnit_Framework_TestCase
+abstract class CacheTest extends TestCase
 {
     /**
      * @dataProvider provideCrudValues

--- a/Tests/runTests.sh
+++ b/Tests/runTests.sh
@@ -13,4 +13,4 @@ echo ''
 echo ''
 echo 'Testing for Coding Styling Compliance.'
 echo 'All code should follow PSR standards.'
-./vendor/fabpot/php-cs-fixer/php-cs-fixer fix ./ --level="all" -vv --dry-run
+./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix ./ -vv --dry-run

--- a/Tests/travis/php_extensions.ini
+++ b/Tests/travis/php_extensions.ini
@@ -1,2 +1,1 @@
-extension="memcache.so"
 extension="memcached.so"

--- a/composer.json
+++ b/composer.json
@@ -25,17 +25,25 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0",
-        "tedivm/stash": "0.14.*",
-        "symfony/config": "~2.1|~3.0",
-        "symfony/http-kernel": "~2.1|~3.0",
-        "symfony/dependency-injection": "~2.1|~3.0"
+        "php": "^7.0",
+        "tedivm/stash": "^0.15",
+        "symfony/config": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/dependency-injection": "^3.4"
+    },
+    "config": {
+        "vendor-dir": "vendor",
+        "sort-packages": true,
+        "platform": {
+            "php": "7.0.8"
+        }
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
-        "fabpot/php-cs-fixer": "0.4.0",
-        "satooshi/php-coveralls": "1.0.*",
-        "doctrine/cache": "~1.0"
+        "doctrine/cache": "^1.6",
+        "friendsofphp/php-cs-fixer": "^2",
+        "php-coveralls/php-coveralls": "^2",
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "*"
     },
     "autoload": {
         "psr-4": {"Tedivm\\StashBundle\\": ""}

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "require": {
         "php": "^7.0",
         "tedivm/stash": "^0.15",
-        "symfony/config": "^3.4",
-        "symfony/http-kernel": "^3.4",
-        "symfony/dependency-injection": "^3.4"
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/http-kernel": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0"
     },
     "config": {
         "vendor-dir": "vendor",


### PR DESCRIPTION
I needed an upgrade for this bundle to prepare a symfony 4 upgrade of our platform. 

I made the code deprecation free. I also needed to update some dev dependencies (phpunit mainly) so I updated the unit tests also.

This PR also drops support for PHP 5.4

There is one issue that could be fixed by this PR https://github.com/tedious/TedivmStashBundle/issues/107